### PR TITLE
Enable Serial Mode with environment variable

### DIFF
--- a/src/scan-binary.sh
+++ b/src/scan-binary.sh
@@ -33,7 +33,7 @@ get_bearer_token() {
 }
 
 get_scan_readiness() {
-    local api_url="${BD_URL}/api/codelocations?q=name:${PROJECT}_${VERSION}_${SUFFIX}_code binary"
+    local api_url="${BD_URL}/api/codelocations?q=name:${PROJECT}_${VERSION}_${SUFFIX}_code%20binary"
     local response
     local bearer_token=$(get_bearer_token)
     response=$(curl -s -H "Authorization: Bearer $bearer_token" "$api_url")

--- a/src/scan-binary.sh
+++ b/src/scan-binary.sh
@@ -26,11 +26,19 @@ fi
 
 # SET BD_URL and BD_API_TOKEN variables to point to your instance of Black Duck
 #
+get_bearer_token() {
+    local bd_url="$1"
+    local api_token="$2"
+    local response
+    response=$(curl -s -X POST -H "Authorization: token $api_token" "$bd_url/api/tokens/authenticate")
+    echo "$response" | grep -oP '"bearerToken"\s*:\s*"\K[^"]+'
+}
 
 get_scan_readiness() {
     local api_url="${BD_URL}/api/codelocations?q=name:${PROJECT}_${VERSION}_${SUFFIX}_code binary"
     local response
-    response=$(curl -s -H "Authorization: Bearer $BD_API_TOKEN" "$api_url")
+    local bearer_token=$(get_bearer_token "$BD_URL" "$BD_API_TOKEN")
+    response=$(curl -s -H "Authorization: Bearer $bearer_token" "$api_url")
 
     # Extract count of IN_PROGRESS status items
     local count

--- a/src/scan-binary.sh
+++ b/src/scan-binary.sh
@@ -27,17 +27,15 @@ fi
 # SET BD_URL and BD_API_TOKEN variables to point to your instance of Black Duck
 #
 get_bearer_token() {
-    local bd_url="$1"
-    local api_token="$2"
     local response
-    response=$(curl -s -X POST -H "Authorization: token $api_token" "$bd_url/api/tokens/authenticate")
+    response=$(curl -s -X POST -H "Authorization: token $BD_API_TOKEN" "$BD_URL/api/tokens/authenticate")
     echo "$response" | grep -oP '"bearerToken"\s*:\s*"\K[^"]+'
 }
 
 get_scan_readiness() {
     local api_url="${BD_URL}/api/codelocations?q=name:${PROJECT}_${VERSION}_${SUFFIX}_code binary"
     local response
-    local bearer_token=$(get_bearer_token "$BD_URL" "$BD_API_TOKEN")
+    local bearer_token=$(get_bearer_token)
     response=$(curl -s -H "Authorization: Bearer $bearer_token" "$api_url")
 
     # Extract count of IN_PROGRESS status items

--- a/src/scanlargefolder.sh
+++ b/src/scanlargefolder.sh
@@ -115,6 +115,13 @@ else
 	exit 1
 fi
 
+
+# Check if we have BD_URL
+if [ -n "$DETECT_SERIAL_MODE" ]
+then
+	echo Serial mode is enabled
+fi
+
 #
 #check if there are files larger than the limit
 FILESOVERLIMIT=$(find $SOURCEFOLDER -type f -size +${SIZELIMIT}c)


### PR DESCRIPTION
This PR enables one to scan one binary slice at a time, waiting through API polling until it's worker is free before sending the next slice. This sort of behavior is necessary in environments such as ours where throttling is required by leadership. The environment variable `$DETECT_SERIAL_MODE` enables this behavior.