### PR TITLE
containzerizes the yasplitter to use on bare host with secrets

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,37 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/yasplitter-scanner:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/yasplitter-scanner:${{ github.sha }}
+          platforms: linux/amd64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM alpine:3.19
+
+# Small scanner image that runs the repo's scanlargefolder.sh script.
+# It installs bash, curl and CA certs so the script can call external services.
+
+# Black Duck server URL (set at runtime)
+ENV BD_URL=""
+ENV JAVA_HOME="/usr/lib/jvm/java-11-openjdk"
+# Default DETECT_SERIAL_MODE to 1 (true-ish). Users can override at runtime.
+ENV DETECT_SERIAL_MODE=1
+
+WORKDIR /app
+
+# install runtime deps
+RUN apk add --no-cache bash curl ca-certificates findutils openjdk11-jre && update-ca-certificates && \
+	apk upgrade
+
+# Copy only the scanner script(s) we need. Keep permissions.
+
+# Copy scanner script and an entrypoint that will load secrets if mounted
+COPY src/*.sh /app/
+RUN chmod +x /app/*.sh
+
+# Use the secure entrypoint which exports secrets (if provided) and then
+# execs the scanner script while forwarding any CLI args.
+ENTRYPOINT ["/bin/bash", "/app/docker-entrypoint.sh"]
+WORKDIR /app
+
+# By using ENTRYPOINT, `docker run <image> <args...>` will pass <args...>
+# to the script. The script expects the source folder path to look like
+# /tmp/<PATH_TO_SOURCE_FOLDER> when mounted into the container at runtime.

--- a/README.md
+++ b/README.md
@@ -41,4 +41,31 @@ bash scanlargefolder.sh <PATH_TO_SOURCE_FOLDER> <PROJECT_NAME> <VERSION_NAME> si
 
 ```
 
+## Docker Guide:
 
+Build the container:
+
+    docker build -t yasplitter-scanner:latest .
+
+Create a secret for your API token.
+
+    echo -n "your_token_here" | docker secret create bd_api_token -
+
+Create a service that uses a mounted secret, mounting the large folder you wish to scan into the container.
+
+    docker service create --name scanner \
+      --secret source=bd_api_token,target=BD_API_TOKEN \
+      -e BD_URL='https://your-blackduck.example' \
+      -v /tmp/large_folder_to_scan:/large_folder_to_scan \
+      yasplitter-scanner:latest /large_folder_to_scan PROJECT VERSION SUFFIX
+
+Run a container with the secret:
+
+    printf '%s' 'your_token_here' > /tmp/bd_token
+
+    # run container and mount the file as /run/secrets/BD_API_TOKEN
+    docker run --rm \
+      -v /tmp/large_folder_to_scan:/large_folder_to_scan \
+      -v /tmp/bd_token:/run/secrets/BD_API_TOKEN:ro \
+      -e BD_URL='https://your-blackduck.example' \
+      yasplitter-scanner:latest /tmp/myproject PROJECT VERSION SUFFIX

--- a/src/docker-entrypoint.sh
+++ b/src/docker-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Entry point that loads BD_API_TOKEN from Docker secrets if present.
+# If /run/secrets/BD_API_TOKEN exists, prefer it over the BD_API_TOKEN env var.
+# After loading the secret, exec the scanner script with all passed arguments.
+
+set -euo pipefail
+
+# If a secret file exists, read its contents into BD_API_TOKEN
+if [ -f "/run/secrets/BD_API_TOKEN" ]; then
+  export BD_API_TOKEN=$(cat /run/secrets/BD_API_TOKEN)
+  echo "Loaded BD_API_TOKEN from /run/secrets/BD_API_TOKEN" >&2
+fi
+
+# Allow passing a file path to a mounted token as well (convention)
+if [ -n "${BD_API_TOKEN_FILE:-}" ] && [ -f "${BD_API_TOKEN_FILE}" ]; then
+  export BD_API_TOKEN=$(cat "${BD_API_TOKEN_FILE}")
+  echo "Loaded BD_API_TOKEN from path in BD_API_TOKEN_FILE" >&2
+fi
+
+# Basic validation: warn if BD_URL or BD_API_TOKEN are empty
+if [ -z "${BD_URL:-}" ]; then
+  echo "Warning: BD_URL is empty. Set BD_URL via -e or Docker secrets." >&2
+fi
+if [ -z "${BD_API_TOKEN:-}" ]; then
+  echo "Warning: BD_API_TOKEN is empty. Provide it via Docker secret or -e BD_API_TOKEN." >&2
+fi
+
+# Exec the scanner script, forwarding args and replacing the shell process.
+exec /bin/bash /app/scanlargefolder.sh "$@"

--- a/src/scan-binary-readiness.sh
+++ b/src/scan-binary-readiness.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+
+PROJECTPATH=$1
+PROJECT=$2
+VERSION=$3
+SUFFIX=$4
+
+DETECT_URL_PATH=https://detect.blackduck.com/detect${DETECT_MAJOR_VERSION:-10}.sh
+
+if [ "$PROJECTPATH" = "" ]
+then
+   echo "specify folder to scan"
+   exit 1
+fi
+
+if [ "$PROJECT" = "" ] 
+then
+  PROJECT=${PROJECTPATH}
+fi
+
+if [ "$VERSION" = "" ]
+then
+  VERSION=LATEST
+fi
+
+# SET BD_URL and BD_API_TOKEN variables to point to your instance of Black Duck
+#
+get_bearer_token() {
+    local response
+    response=$(curl -s -X POST -H "Authorization: token $BD_API_TOKEN" "$BD_URL/api/tokens/authenticate")
+    echo "$response" | grep -oP '"bearerToken"\s*:\s*"\K[^"]+'
+}
+
+get_scan_readiness() {
+    local api_url="${BD_URL}/api/codelocations?q=name:${PROJECT}_${VERSION}_${SUFFIX}_code%20binary"
+    echo "API URL: $api_url"
+    local response
+    local bearer_token=$(get_bearer_token)
+    response=$(curl -s -H "Authorization: Bearer $bearer_token" "$api_url")
+    echo "Response: $response"
+
+    # Extract count of IN_PROGRESS status items
+    local count
+    count=$(echo "$response" | grep -o '"status":[^]]*' | grep -c 'IN_PROGRESS')
+    echo "Count of IN_PROGRESS scans: $count"
+
+    # Return 0 if no scans are in progress (ready), 1 otherwise (not ready)
+    if [ "$count" -eq 0 ]; then
+        echo "No scans in progress. Scan is ready."
+        return 0
+    else
+        echo "Scans are still in progress."
+        return 1
+    fi
+}
+
+# bash <(curl -s -L $DETECT_URL_PATH) \
+#      --blackduck.url=$BD_URL \
+#      --blackduck.api.token=$BD_API_TOKEN \
+#      --blackduck.trust.cert=true \
+#      --detect.binary.scan.file.path=${PROJECTPATH} \
+#      --detect.tools=BINARY_SCAN \
+#      --detect.project.name=${PROJECT} \
+#      --detect.project.version.name=${VERSION} \
+#      --detect.code.location.name=${PROJECT}_${VERSION}_${SUFFIX}_code \
+
+if [ "$DETECT_SERIAL_MODE" = "true" ] || [ "$DETECT_SERIAL_MODE" = "TRUE" ]; then
+  # Wait for scan readiness
+  echo "Waiting for scan readiness..."
+  while ! get_scan_readiness; do
+      echo "Scan is still in progress. Waiting 30 seconds before rechecking..."
+      sleep 30
+  done
+  echo "Scan completed."
+fi


### PR DESCRIPTION
I wanted to be able to run this from a linux machine without much fuss like installing java, etc. So I containerized yasplitter to have all the requirements and then be able to pass the API token as a secret.